### PR TITLE
Fix: IO DATA -> I-O DATA

### DIFF
--- a/public/words/words.json
+++ b/public/words/words.json
@@ -48,7 +48,7 @@
         "actor": "VOICEVOX ずんだもん"
     },
     {
-        "word": "IO DATA",
+        "word": "I-O DATA",
         "pronounciation": "硫黄ダテエ",
         "description": "",
         "actor": "VOICEVOX ずんだもん"


### PR DESCRIPTION
>「I/O DATA」や「IO DATA」などと誤記される場合がある。
https://ja.wikipedia.org/wiki/%E3%82%A2%E3%82%A4%E3%83%BB%E3%82%AA%E3%83%BC%E3%83%BB%E3%83%87%E3%83%BC%E3%82%BF%E6%A9%9F%E5%99%A8